### PR TITLE
Adjusted currency multiplication logic

### DIFF
--- a/src/cn-flex-form.service.js
+++ b/src/cn-flex-form.service.js
@@ -734,7 +734,16 @@ function CNFlexFormService(
                   let p = schema && schema.format === 'currency-dollars' ? 2 : 0;
 
                   if(adjustment.math[1] === '*') {
-                    result = _.floor(result, p);
+                    let bottom = _.floor(result, p);
+                    if(bottom % 10 == 9) {
+                      result = bottom + 1;
+                    }
+                    else if(bottom % 10 == 1) {
+                      result = bottom - 1;
+                    }
+                    else {
+                      result = bottom;
+                    }
                   }
                   else if(adjustment.math[1] === '/') {
                     result = _.ceil(result, p);


### PR DESCRIPTION
Pulls towards multiples of ten. This will cause it to calculate incorrectly for many more values than normal (a total budget of $9.99 will effectively be impossible), but it will look correct for the most commonly used values.
FBCM-2413